### PR TITLE
Add preferences API

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import { AxiosError, AxiosPromise, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { IResourceCreateQueryParams, IResources, WorkspaceSettings } from './resources';
+import { IResourceCreateQueryParams, IResources, WorkspaceSettings, Preferences } from './resources';
 import { che } from '@eclipse-che/api';
 
 export enum METHOD {
@@ -87,10 +87,15 @@ export interface IRemoteAPI {
     getSshKey<T = che.ssh.SshPair>(service: string, name: string): Promise<T>;
     getAllSshKey<T = che.ssh.SshPair>(service: string): Promise<T[]>;
     deleteSshKey(service: string, name: string): Promise<void>;
+    getUserPreferences(): Promise<Preferences>;
+    getUserPreferences(filter: string | undefined): Promise<Preferences>;
+    updateUserPreferences(update: Preferences): Promise<Preferences>;
+    replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
+    deleteUserPreferences(): Promise<void>;
+    deleteUserPreferences(list: string[] | undefined): Promise<void>;
 }
 
 export class RemoteAPI implements IRemoteAPI {
-
     private promises: Map<string, AxiosPromise<any>> = new Map();
 
     private remoteAPI: IResources;
@@ -385,6 +390,54 @@ export class RemoteAPI implements IRemoteAPI {
             this.remoteAPI.deleteSshKey(service, name)
                 .then((response: AxiosResponse) => {
                     resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    public getUserPreferences(filter: string | undefined = undefined): Promise<Preferences> {
+        return new Promise((resolve, reject) => {
+            this.remoteAPI.getUserPreferences(filter)
+                .then((response: AxiosResponse<Preferences>) => {
+                    resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    public updateUserPreferences(update: Preferences): Promise<Preferences> {
+        return new Promise((resolve, reject) => {
+            this.remoteAPI.updateUserPreferences(update)
+                .then((response: AxiosResponse<Preferences>) => {
+                    resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    public replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
+         return new Promise((resolve, reject) => {
+            this.remoteAPI.replaceUserPreferences(preferences)
+                .then((response: AxiosResponse<Preferences>) => {
+                    resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    public deleteUserPreferences(list: string[] | undefined = undefined): Promise<void> {
+         return new Promise((resolve, reject) => {
+            this.remoteAPI.deleteUserPreferences(list)
+                .then((response: AxiosResponse<void>) => {
+                    resolve();
                 })
                 .catch((error: AxiosError) => {
                     reject(new RequestError(error));

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -22,6 +22,9 @@ export interface IResourceCreateQueryParams extends IResourceQueryParams {
 export interface IResourceQueryParams {
     [propName: string]: string | undefined;
 }
+export interface Preferences {
+    [key: string]: string;
+}
 
 export interface IResources {
     getAll: <T>() => AxiosPromise<T[]>;
@@ -40,6 +43,10 @@ export interface IResources {
     getSshKey: <T>(service: string, name: string) => AxiosPromise<T>;
     getAllSshKey: <T>(service: string) => AxiosPromise<T[]>;
     deleteSshKey(service: string, name: string): AxiosPromise<void>;
+    getUserPreferences(filter: string | undefined): AxiosPromise<Preferences>;
+    updateUserPreferences(update: Preferences): AxiosPromise<Preferences>;
+    replaceUserPreferences(preferences: Preferences): AxiosPromise<Preferences>;
+    deleteUserPreferences(list: string[] | undefined): AxiosPromise<void>;
 }
 
 export class Resources implements IResources {
@@ -194,6 +201,48 @@ export class Resources implements IResources {
             method: 'DELETE',
             baseURL: this.baseUrl,
             url: `/ssh/${service}?name=${name}`
+        });
+    }
+
+    public getUserPreferences(filter: string | undefined = undefined): AxiosPromise<Preferences> {
+        return this.axios.request<Preferences>({
+            method: 'GET',
+            baseURL: this.baseUrl,
+            url: filter ? `/preferences?filter=${filter}` : '/preferences'
+        });
+    }
+
+    public updateUserPreferences(update: Preferences): AxiosPromise<Preferences> {
+        return this.axios.request<Preferences>({
+            method: 'PUT',
+            baseURL: this.baseUrl,
+            url: `/preferences`,
+            data: update
+        });
+    }
+
+    public replaceUserPreferences(preferences: Preferences): AxiosPromise<Preferences> {
+        return this.axios.request<Preferences>({
+            method: 'POST',
+            baseURL: this.baseUrl,
+            url: `/preferences`,
+            data: preferences
+        });
+    }
+
+    public deleteUserPreferences(list: string[] | undefined = undefined): AxiosPromise<void> {
+        if (list) {
+            return this.axios.request<void>({
+                method: 'DELETE',
+                baseURL: this.baseUrl,
+                url: `/preferences`,
+                data: list
+            });
+        }
+        return this.axios.request<void>({
+            method: 'DELETE',
+            baseURL: this.baseUrl,
+            url: `/preferences`
         });
     }
 

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -46,4 +46,21 @@ describe('RestAPI >', () => {
         });
     });
 
+    it('should receive all user preferences', (done) => {
+        backend.stubRequest('GET', '/preferences', {
+            status: 200,
+            responseText: '{"key1":"value", "key2": 5}'
+        });
+
+        const spySucceed = jasmine.createSpy('succeed');
+        const spyFailed = jasmine.createSpy('failed');
+        restApi.getUserPreferences().then(spySucceed, spyFailed);
+
+        backend.wait(() => {
+            expect(spySucceed.calls.count()).toEqual(1);
+            expect(spyFailed.calls.count()).toEqual(0);
+            done();
+        });
+    });
+
 });


### PR DESCRIPTION
Adds methods to work with Che preferences.
Note, Che server side doesn't handle nested objects, so in that case objects have to be stringified first.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>