### PR TITLE
chore(github): Update issue template to use external main che repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Where to report issues?"
+about: File issues in the main Eclipse Che repository at https://github.com/eclipse/che/issues
+title: Issues need to be filed in the main Eclipse Che repository
+labels: ''
+assignees: ''
+
+---
+
+## Where to report issues?
+
+This repository is not the primary repository of Eclipse Che.
+
+🚨 Please don't submit new issues here. 🚨
+
+All issues for Eclipse Che are managed at [https://github.com/eclipse/che/issues](https://github.com/eclipse/che/issues).


### PR DESCRIPTION
### What does this PR do?
Provide template to create issues in main Eclipse Che repository

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13637

Change-Id: I79ddc7dba9aa09305199ddfb7c2808fbd46e992e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>