### PR TITLE
Add getOAuthProviders() API method

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -95,6 +95,7 @@ export interface IRemoteAPI {
     deleteUserPreferences(): Promise<void>;
     deleteUserPreferences(list: string[] | undefined): Promise<void>;
     getOAuthToken(oAuthProvider: string): Promise<string>;
+    getOAuthProviders(): Promise<string[]>;
 }
 
 export class RemoteAPI implements IRemoteAPI {
@@ -464,6 +465,18 @@ export class RemoteAPI implements IRemoteAPI {
             this.remoteAPI.getOAuthToken(oAuthProvider)
                 .then((response: AxiosResponse<{ token: string }>) => {
                     resolve(response.data.token);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    getOAuthProviders(): Promise<string[]> {
+        return new Promise<string[]>((resolve, reject) => {
+            this.remoteAPI.getOAuthProviders()
+                .then((response: AxiosResponse<any[]>) => {
+                    resolve(response.data.map(provider => provider.name));
                 })
                 .catch((error: AxiosError) => {
                     reject(new RequestError(error));

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -48,6 +48,7 @@ export interface IResources {
     createSshKey: (sshKeyPair: che.ssh.SshPair) => AxiosPromise<void>;
     getSshKey: <T>(service: string, name: string) => AxiosPromise<T>;
     getAllSshKey: <T>(service: string) => AxiosPromise<T[]>;
+    getOAuthProviders: () => AxiosPromise<any[]>;
     deleteSshKey(service: string, name: string): AxiosPromise<void>;
     getCurrentUser(): AxiosPromise<User>;
     getUserPreferences(filter: string | undefined): AxiosPromise<Preferences>;
@@ -268,6 +269,14 @@ export class Resources implements IResources {
             method: 'GET',
             baseURL: this.baseUrl,
             url: `/oauth/token?oauth_provider=${oAuthProvider}`
+        });
+    }
+
+    public getOAuthProviders(): AxiosPromise<any[]> {
+        return this.axios.request<any[]>({
+            method: 'GET',
+            baseURL: this.baseUrl,
+            url: '/oauth'
         });
     }
 


### PR DESCRIPTION
Add getOAuthProviders() API method
is needed for https://github.com/che-incubator/che-theia-openshift-auth/pull/1