### PR TITLE
Add an ability to sign requests with user token

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -87,15 +87,15 @@ export interface IRemoteAPI {
     getSshKey<T = che.ssh.SshPair>(service: string, name: string): Promise<T>;
     getAllSshKey<T = che.ssh.SshPair>(service: string): Promise<T[]>;
     deleteSshKey(service: string, name: string): Promise<void>;
-    getCurrentUser(): Promise<User>;
+    getCurrentUser(token?: string): Promise<User>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
     replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
     deleteUserPreferences(): Promise<void>;
     deleteUserPreferences(list: string[] | undefined): Promise<void>;
-    getOAuthToken(oAuthProvider: string): Promise<string>;
-    getOAuthProviders(): Promise<string[]>;
+    getOAuthToken(oAuthProvider: string, token?: string): Promise<string>;
+    getOAuthProviders(token?: string): Promise<string[]>;
     updateActivity(workspaceId: string): Promise<void>;
 }
 
@@ -401,9 +401,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getCurrentUser(): Promise<User> {
+    getCurrentUser(token?: string): Promise<User> {
         return new Promise((resolve, reject) => {
-            this.remoteAPI.getCurrentUser()
+            this.remoteAPI.getCurrentUser(token)
                 .then((response: AxiosResponse<User>) => {
                     resolve(response.data);
                 })
@@ -461,9 +461,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getOAuthToken(oAuthProvider: string): Promise<string> {
+    getOAuthToken(oAuthProvider: string, token?: string): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.remoteAPI.getOAuthToken(oAuthProvider)
+            this.remoteAPI.getOAuthToken(oAuthProvider, token)
                 .then((response: AxiosResponse<{ token: string }>) => {
                     resolve(response.data.token);
                 })
@@ -473,9 +473,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getOAuthProviders(): Promise<string[]> {
+    getOAuthProviders(token?: string): Promise<string[]> {
         return new Promise<string[]>((resolve, reject) => {
-            this.remoteAPI.getOAuthProviders()
+            this.remoteAPI.getOAuthProviders(token)
                 .then((response: AxiosResponse<any[]>) => {
                     resolve(response.data.map(provider => provider.name));
                 })

--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -87,6 +87,12 @@ export interface IRemoteAPI {
     getSshKey<T = che.ssh.SshPair>(service: string, name: string): Promise<T>;
     getAllSshKey<T = che.ssh.SshPair>(service: string): Promise<T[]>;
     deleteSshKey(service: string, name: string): Promise<void>;
+    /**
+     * Return the current authenticated user
+     *
+     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
+     *  the authorization header from the default headers list will be set.
+     */
     getCurrentUser(token?: string): Promise<User>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
@@ -94,7 +100,20 @@ export interface IRemoteAPI {
     replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
     deleteUserPreferences(): Promise<void>;
     deleteUserPreferences(list: string[] | undefined): Promise<void>;
+    /**
+     * Return registered oauth token.
+     *
+     * @param oAuthProvider oauth provider's name e.g. github.
+     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
+     *  the authorization header from the default headers list will be set.
+     */
     getOAuthToken(oAuthProvider: string, token?: string): Promise<string>;
+    /**
+     * Return list of registered oAuth providers.
+     *
+     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
+     *  the authorization header from the default headers list will be set.
+     */
     getOAuthProviders(token?: string): Promise<string[]>;
     updateActivity(workspaceId: string): Promise<void>;
 }

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -48,14 +48,14 @@ export interface IResources {
     createSshKey: (sshKeyPair: che.ssh.SshPair) => AxiosPromise<void>;
     getSshKey: <T>(service: string, name: string) => AxiosPromise<T>;
     getAllSshKey: <T>(service: string) => AxiosPromise<T[]>;
-    getOAuthProviders: () => AxiosPromise<any[]>;
+    getOAuthProviders: (token?: string) => AxiosPromise<any[]>;
     deleteSshKey(service: string, name: string): AxiosPromise<void>;
-    getCurrentUser(): AxiosPromise<User>;
+    getCurrentUser(token?: string): AxiosPromise<User>;
     getUserPreferences(filter: string | undefined): AxiosPromise<Preferences>;
     updateUserPreferences(update: Preferences): AxiosPromise<Preferences>;
     replaceUserPreferences(preferences: Preferences): AxiosPromise<Preferences>;
     deleteUserPreferences(list: string[] | undefined): AxiosPromise<void>;
-    getOAuthToken(oAuthProvider: string): AxiosPromise<{ token: string }>;
+    getOAuthToken(oAuthProvider: string, token?: string): AxiosPromise<{ token: string }>;
     updateActivity(workspaceId: string): AxiosPromise<void>;
 }
 
@@ -207,9 +207,10 @@ export class Resources implements IResources {
         });
     }
 
-    public getCurrentUser(): AxiosPromise<User> {
+    public getCurrentUser(token?: string): AxiosPromise<User> {
         return this.axios.request<User>({
             method: 'GET',
+            headers: this.getDefaultHeadersWithAuthorization(token),
             baseURL: this.baseUrl,
             url: `/user`
         });
@@ -265,17 +266,19 @@ export class Resources implements IResources {
         });
     }
 
-    public getOAuthToken(oAuthProvider: string): AxiosPromise<{ token: string }> {
+    public getOAuthToken(oAuthProvider: string, token?: string): AxiosPromise<{ token: string }> {
         return this.axios.request<{ token: string }>({
             method: 'GET',
+            headers: this.getDefaultHeadersWithAuthorization(token),
             baseURL: this.baseUrl,
             url: `/oauth/token?oauth_provider=${oAuthProvider}`
         });
     }
 
-    public getOAuthProviders(): AxiosPromise<any[]> {
+    public getOAuthProviders(token?: string): AxiosPromise<any[]> {
         return this.axios.request<any[]>({
             method: 'GET',
+            headers: this.getDefaultHeadersWithAuthorization(token),
             baseURL: this.baseUrl,
             url: '/oauth'
         });
@@ -287,6 +290,20 @@ export class Resources implements IResources {
             baseURL: this.baseUrl,
             url: `/activity/${workspaceId}`
         });
+    }
+
+    private getDefaultHeadersWithAuthorization(token?: string): { [key: string]: string } {
+        const headers: { [key: string]: string } = {};
+        for (const key in this.headers) {
+            if (this.headers.hasOwnProperty(key)) {
+                headers[key] = this.headers[key];
+            }
+        }
+        if (token) {
+            const header  = 'Authorization';
+            headers[header] = 'Bearer ' + token;
+        }
+        return headers;
     }
 
     private encode(params: IResourceQueryParams): string {


### PR DESCRIPTION
oauth methods such as `getToken()` and `getOauthProviders()` don't work work with machine token. Add an ability to sign such requests with user (keykloak) token

Is needed for https://github.com/eclipse/che/pull/16488