### PR TITLE
Provide user access token for filtered REST API methods in workspace service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ export interface IRestAPIConfig {
     // path to self signed certificate
     ssCrtPath?: string;
     loggingEnabled?: boolean;
+    machineToken?: string;
+    userToken?: string;
 }
 
 export default class WorkspaceClient {
@@ -43,7 +45,7 @@ export default class WorkspaceClient {
 
         const headers = config.headers || {};
 
-        const resources = new Resources(this.createAxiosInstance(config), baseUrl, headers);
+        const resources = new Resources(this.createAxiosInstance(config), baseUrl, headers, config.machineToken, config.userToken);
         return new RemoteAPI(resources);
     }
 

--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -89,11 +89,8 @@ export interface IRemoteAPI {
     deleteSshKey(service: string, name: string): Promise<void>;
     /**
      * Return the current authenticated user
-     *
-     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
-     *  the authorization header from the default headers list will be set.
      */
-    getCurrentUser(token?: string): Promise<User>;
+    getCurrentUser(): Promise<User>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
@@ -104,17 +101,12 @@ export interface IRemoteAPI {
      * Return registered oauth token.
      *
      * @param oAuthProvider oauth provider's name e.g. github.
-     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
-     *  the authorization header from the default headers list will be set.
      */
-    getOAuthToken(oAuthProvider: string, token?: string): Promise<string>;
+    getOAuthToken(oAuthProvider: string): Promise<string>;
     /**
      * Return list of registered oAuth providers.
-     *
-     * @param token keycloak user token should be used for requesting CheAPI. In case it's missing -
-     *  the authorization header from the default headers list will be set.
      */
-    getOAuthProviders(token?: string): Promise<string[]>;
+    getOAuthProviders(): Promise<string[]>;
     updateActivity(workspaceId: string): Promise<void>;
 }
 
@@ -420,9 +412,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getCurrentUser(token?: string): Promise<User> {
+    getCurrentUser(): Promise<User> {
         return new Promise((resolve, reject) => {
-            this.remoteAPI.getCurrentUser(token)
+            this.remoteAPI.getCurrentUser()
                 .then((response: AxiosResponse<User>) => {
                     resolve(response.data);
                 })
@@ -480,9 +472,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getOAuthToken(oAuthProvider: string, token?: string): Promise<string> {
+    getOAuthToken(oAuthProvider: string): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.remoteAPI.getOAuthToken(oAuthProvider, token)
+            this.remoteAPI.getOAuthToken(oAuthProvider)
                 .then((response: AxiosResponse<{ token: string }>) => {
                     resolve(response.data.token);
                 })
@@ -492,9 +484,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getOAuthProviders(token?: string): Promise<string[]> {
+    getOAuthProviders(): Promise<string[]> {
         return new Promise<string[]>((resolve, reject) => {
-            this.remoteAPI.getOAuthProviders(token)
+            this.remoteAPI.getOAuthProviders()
                 .then((response: AxiosResponse<any[]>) => {
                     resolve(response.data.map(provider => provider.name));
                 })

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -36,7 +36,7 @@ describe('RestAPI >', () => {
       );
         await restApi.getAll();
         expect(axios.request).toHaveBeenCalledTimes(1);
-        expect(axios.request).toHaveBeenCalledWith({'baseURL': '/api', 'method': 'GET', 'url': '/workspace'});
+        expect(axios.request).toHaveBeenCalledWith({'baseURL': '/api', 'headers': {}, 'method': 'GET', 'url': '/workspace'});
 
     });
 
@@ -50,7 +50,7 @@ describe('RestAPI >', () => {
         const preferences = await restApi.getUserPreferences();
 
         expect(axios.request).toHaveBeenCalledTimes(1);
-        expect(axios.request).toHaveBeenCalledWith({'baseURL': '/api', 'method': 'GET', 'url': '/preferences'});
+        expect(axios.request).toHaveBeenCalledWith({'baseURL': '/api', 'headers':{}, 'method': 'GET', 'url': '/preferences'});
         expect(preferences).toBeDefined();
         expect(preferences).toHaveProperty('key1');
         expect(preferences).toHaveProperty('key2');


### PR DESCRIPTION
This changes proposal adds an ability to configure user access token among with machine token to be able to call workspace service methods which are under filtering. In Che-Theia configuration can be still the same (provided by additional header with bearer token), but on the other hand it is possible now to provide user and machine token via configuration object:

```typescript
            const restAPIConfig: IRestAPIConfig = {
                baseUrl: url,
                headers: {
                    restAPIConfig.headers['Authorization'] = 'Bearer ' + token;
                }
            };
```

or via configuration fields:

```typescript
            const restAPIConfig: IRestAPIConfig = {
                baseUrl: url,
                machineToken: mToken,
                userToken: uToken
            };
```

Needed for: https://github.com/eclipse/che/issues/17246

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>