### PR TITLE
Support custom public certificates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { Resources } from './rest/resources';
 import { IWorkspaceMasterApi, WorkspaceMasterApi } from './json-rpc/workspace-master-api';
 import { WebSocketClient } from './json-rpc/web-socket-client';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as https from 'https';
 import * as url from 'url';
 import * as tunnel from 'tunnel';
@@ -26,6 +27,8 @@ export interface IRestAPIConfig {
     headers?: any;
     // path to self signed certificate
     ssCrtPath?: string;
+    // path to public certificates
+    publicCrtPath?: string;
     loggingEnabled?: boolean;
     machineToken?: string;
     userToken?: string;
@@ -75,11 +78,11 @@ export default class WorkspaceClient {
                 const httpOverHttpsAgent = tunnel.httpOverHttps({ proxy: httpsProxyOptions });
                 const httpsOverHttpAgent = tunnel.httpsOverHttp({
                     proxy: mainProxyOptions,
-                    ca: certificateAuthority ? [certificateAuthority] : undefined
+                    ca: certificateAuthority
                 });
                 const httpsOverHttpsAgent = tunnel.httpsOverHttps({
                     proxy: httpsProxyOptions,
-                    ca: certificateAuthority ? [certificateAuthority] : undefined
+                    ca: certificateAuthority
                 });
                 const urlIsHttps = (parsedBaseUrl.protocol || 'http:').startsWith('https:');
                 const proxyIsHttps = (parsedProxyUrl.protocol || 'http:').startsWith('https:');
@@ -125,12 +128,23 @@ export default class WorkspaceClient {
         });
     }
 
-    private static getCertificateAuthority(config: IRestAPIConfig): Buffer | undefined {
-        let certificateAuthority: Buffer | undefined;
+    private static getCertificateAuthority(config: IRestAPIConfig): Buffer[] | undefined {
+        const certificateAuthority: Buffer[] = [];
         if (config.ssCrtPath && fs.existsSync(config.ssCrtPath)) {
-            certificateAuthority = fs.readFileSync(config.ssCrtPath);
+            certificateAuthority.push(fs.readFileSync(config.ssCrtPath));
         }
-        return certificateAuthority;
+
+        if (config.publicCrtPath && fs.existsSync(config.publicCrtPath)) {
+            const publicCertificates = fs.readdirSync(config.publicCrtPath);
+            for (const publicCertificate of publicCertificates) {
+                if (publicCertificate.endsWith('.crt')) {
+                    const certPath = path.join(config.publicCrtPath, publicCertificate);
+                    certificateAuthority.push(fs.readFileSync(certPath));
+                }
+            }
+        }
+
+        return certificateAuthority.length > 0 ? certificateAuthority : undefined;
     }
 
     private static getMainProxyOptions(parsedProxyUrl: url.UrlWithStringQuery): tunnel.ProxyOptions {
@@ -142,13 +156,13 @@ export default class WorkspaceClient {
         };
     }
 
-    private static getHttpsProxyOptions(mainProxyOptions: tunnel.ProxyOptions, servername: string | undefined, certificateAuthority: Buffer | undefined): tunnel.HttpsProxyOptions {
+    private static getHttpsProxyOptions(mainProxyOptions: tunnel.ProxyOptions, servername: string | undefined, certificateAuthority: Buffer[] | undefined): tunnel.HttpsProxyOptions {
         return {
             host: mainProxyOptions.host,
             port: mainProxyOptions.port,
             proxyAuth: mainProxyOptions.proxyAuth,
             servername,
-            ca: certificateAuthority ? [certificateAuthority] : undefined
+            ca: certificateAuthority
         };
     }
 


### PR DESCRIPTION
This changes proposal adds an ability to provide custom certificates. 
There is a new field in api configuration, called `publicCrtPath`, which represents a simple directory on file system, where certificates `*.crt` are located. All those certificates take into account during user requests.

```
export interface IRestAPIConfig {
    baseUrl?: string;
    headers?: any;
    // path to self signed certificate
    ssCrtPath?: string;
    // path to public certificates
>>    publicCrtPath?: string;
    loggingEnabled?: boolean;
    machineToken?: string;
    userToken?: string;
}
```

Issue: https://github.com/eclipse/che/issues/17440

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>