### PR TITLE
Revert to 0.0.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-che/workspace-client",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "",
   "main": "dist/server.js",
   "browser": "dist/client.js",


### PR DESCRIPTION
It should be fixed 0.0.1. The build script for Travis-CI assumes 0.0.1 as the current version.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>