### PR TITLE
Add token even if headers are absent in config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,11 +54,12 @@ export default class WorkspaceClient {
                     axios.defaults.headers.common[key] = config.headers[key];
                 }
             }
-            const token = config.userToken ? config.userToken : config.machineToken;
-            if (token) {
-                const header = 'Authorization';
-                axios.defaults.headers.common[header] = `Bearer ${token}`;
-            }
+        }
+        
+        const token = config.userToken ? config.userToken : config.machineToken;
+        if (token) {
+            const header = 'Authorization';
+            axios.defaults.headers.common[header] = `Bearer ${token}`;
         }
 
         const resources = new Resources(axios, baseUrl);
@@ -164,7 +165,7 @@ export default class WorkspaceClient {
         const port = Number(parsedProxyUrl.port);
         return {
             host: parsedProxyUrl.hostname!,
-            port: ( parsedProxyUrl.port !== '' && !isNaN(port)) ? port : 3128,
+            port: (parsedProxyUrl.port !== '' && !isNaN(port)) ? port : 3128,
             proxyAuth: (parsedProxyUrl.auth && parsedProxyUrl.auth !== '') ? parsedProxyUrl.auth : undefined
         };
     }


### PR DESCRIPTION
The PR https://github.com/eclipse/che-workspace-client/pull/39 brought breaking changes for che-theia: https://github.com/eclipse/che/issues/18255

After merging https://github.com/eclipse/che-workspace-client/pull/39 a `token` is added if `headers` exists in a config: https://github.com/eclipse/che-workspace-client/pull/39/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R51.

My propose is: take out adding a token from `if (config.headers)` condition.

Please let me know if the changes related to adding token within https://github.com/eclipse/che-workspace-client/pull/39 are correct and we should apply some adaptation for it on che-theia side.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>