### PR TITLE
Add getApiInfo api call

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -177,6 +177,10 @@ export interface IRemoteAPI {
      * Returns a devfile schema object.
      */
     getDevfileSchema<T = Object>(): Promise<T>;
+    /**
+     * Returns the che server api information
+     */
+    getApiInfo<T = Object>(): Promise<T>;
 }
 
 export class RemoteAPI implements IRemoteAPI {
@@ -503,6 +507,18 @@ export class RemoteAPI implements IRemoteAPI {
     getDevfileSchema<T = Object>(): Promise<T> {
         return new Promise<T>((resolve, reject) => {
             this.remoteAPI.getDevfileSchema<T>()
+                .then((response: AxiosResponse<T>) => {
+                    resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    getApiInfo<T = Object>(): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            this.remoteAPI.getApiInfo<T>()
                 .then((response: AxiosResponse<T>) => {
                     resolve(response.data);
                 })

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -79,6 +79,7 @@ export interface IResources {
     updateActivity(workspaceId: string): AxiosPromise<void>;
     getKubernetesNamespace<T>(): AxiosPromise<T>;
     getDevfileSchema<T>(): AxiosPromise<T>;
+    getApiInfo<T>(): AxiosPromise<T>;
 }
 
 export class Resources implements IResources {
@@ -322,6 +323,13 @@ export class Resources implements IResources {
             method: 'GET',
             baseURL: this.baseUrl,
             url: '/kubernetes/namespace',
+        });
+    }
+
+    public getApiInfo<T>(): AxiosPromise<T> {
+        return this.axios.request<T>({
+            method: 'OPTIONS',
+            baseURL: this.baseUrl,
         });
     }
 }


### PR DESCRIPTION
This PR makes it so that you can get the che server api information through the workspace client.

Related PR: https://github.com/che-incubator/che-dashboard-next/pull/97

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>