### PR TITLE
Add websocket failed event

### DIFF
--- a/src/json-rpc/workspace-master-api.ts
+++ b/src/json-rpc/workspace-master-api.ts
@@ -31,10 +31,10 @@ enum MasterScopes {
 const SUBSCRIBE = 'subscribe';
 const UNSUBSCRIBE = 'unsubscribe';
 
-export type WebSocketsFailedCallback = (entrypoint: string) => void;
+export type WebSocketsStatusChangeCallback = (failingWebSockets: string[]) => void;
 
 export interface IWorkspaceMasterApi {
-    onDidWebSocketFail(callback: WebSocketsFailedCallback): void;
+    onDidWebSocketStatusChange(callback: WebSocketsStatusChangeCallback): void;
     connect(entryPoint: string): Promise<any>;
     subscribeEnvironmentOutput(workspaceId: string, callback: Function): void;
     unSubscribeEnvironmentOutput(workspaceId: string, callback: Function): void;
@@ -61,24 +61,27 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
     private jsonRpcApiClient: JsonRpcApiClient;
     private clientId: string;
     private wsMasterEventEmitter: EventEmitter;
-    private webSocketFailedEventName = 'websocketChanged';
+    private webSocketStatusChangeEventName = 'websocketChanged';
 
-    private maxReconnectionAttempts = 5;
+    private maxReconnectionAttempts = 30;
     private reconnectionAttemptNumber = 0;
-    private reconnectionDelay = 3000;
+    private reconnectionDelay = 30000;
+    private reconnectionInitialDelay = 1000;
+    private failingWebsockets: Set<string>;
 
     constructor (client: ICommunicationClient,
                  entryPoint: string) {
-        client.addListener('open', () => this.onConnectionOpen());
+        client.addListener('open', () => this.onConnectionOpen(entryPoint));
         client.addListener('close', () => this.onConnectionClose(entryPoint));
 
         this.clientId = '';
         this.jsonRpcApiClient = new JsonRpcApiClient(client);
         this.wsMasterEventEmitter = new EventEmitter();
+        this.failingWebsockets = new Set();
     }
 
-    onDidWebSocketFail(callback: WebSocketsFailedCallback): void {
-        this.wsMasterEventEmitter.on(this.webSocketFailedEventName, callback);
+    onDidWebSocketStatusChange(callback: WebSocketsStatusChangeCallback): void {
+        this.wsMasterEventEmitter.on(this.webSocketStatusChangeEventName, callback);
     }
 
     /**
@@ -250,8 +253,10 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
         return this.clientId;
     }
 
-    private onConnectionOpen(): void {
+    private onConnectionOpen(entryPoint: string): void {
         if (this.reconnectionAttemptNumber !== 0) {
+            this.failingWebsockets.delete(entryPoint);
+            this.wsMasterEventEmitter.emit(this.webSocketStatusChangeEventName, this.failingWebsockets);
             console.warn('WebSocket connection is opened.');
         }
         this.reconnectionAttemptNumber = 0;
@@ -259,15 +264,24 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
 
     private onConnectionClose(entryPoint: string): void {
         console.warn('WebSocket connection is closed.');
-        if (this.reconnectionAttemptNumber === this.maxReconnectionAttempts) {
-            this.wsMasterEventEmitter.emit(this.webSocketFailedEventName, entryPoint);
+        if (this.reconnectionAttemptNumber === 5) {
+            this.failingWebsockets.add(entryPoint);
+            this.wsMasterEventEmitter.emit(this.webSocketStatusChangeEventName, this.failingWebsockets);
+        } else if (this.reconnectionAttemptNumber === this.maxReconnectionAttempts) {
             console.warn('The maximum number of attempts to reconnect WebSocket has been reached.');
             return;
         }
 
         this.reconnectionAttemptNumber++;
-        // let very first reconnection happens immediately after the connection is closed.
-        const delay = this.reconnectionAttemptNumber === 1 ? 0 : this.reconnectionDelay;
+        let delay: number;
+        if (this.reconnectionAttemptNumber === 1) {
+            // let very first reconnection happens immediately after the connection is closed.
+            delay = 0;
+        } else if (this.reconnectionAttemptNumber <= 10) {
+            delay = this.reconnectionInitialDelay;
+        } else {
+            delay = this.reconnectionDelay;
+        }
 
         if (delay) {
             console.warn(`WebSocket will be reconnected in ${delay} ms...`);


### PR DESCRIPTION
### What does this PR do?
This PR adds onDidWebSocketStatusChange so you can listen when a websocket is failing to connect. Also, the first 10 websocket reconnections are checked every second. After 5 seconds the websocket will emit the websocket status changed message. After 10 reconnections the websockets are checked every 30 seconds up until 30 reconnection attempts. This is needed on the dashboard-next side so that when/if a websocket fails to connect we can get that from the dashboard-next side

### Which issue is this PR related to?
Pre-req for https://github.com/eclipse/che/issues/18490

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>