### PR TITLE
Add in ability to refresh token before connecting/reconnecting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export default class WorkspaceClient {
         return new RemoteAPI(resources);
     }
 
-    public static getJsonRpcApi(entryPoint: string, refreshToken: RefreshToken): IWorkspaceMasterApi {
+    public static getJsonRpcApi(entryPoint: string, refreshToken?: RefreshToken): IWorkspaceMasterApi {
         const transport = new WebSocketClient();
         return new WorkspaceMasterApi(transport, entryPoint, refreshToken);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import axios, { AxiosInstance, AxiosStatic, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { IRemoteAPI, RemoteAPI } from './rest/remote-api';
 import { Resources } from './rest/resources';
-import { IWorkspaceMasterApi, WorkspaceMasterApi } from './json-rpc/workspace-master-api';
+import { IWorkspaceMasterApi, RefreshToken, WorkspaceMasterApi } from './json-rpc/workspace-master-api';
 import { WebSocketClient } from './json-rpc/web-socket-client';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -66,9 +66,9 @@ export default class WorkspaceClient {
         return new RemoteAPI(resources);
     }
 
-    public static getJsonRpcApi(entryPoint: string): IWorkspaceMasterApi {
+    public static getJsonRpcApi(entryPoint: string, refreshToken: RefreshToken): IWorkspaceMasterApi {
         const transport = new WebSocketClient();
-        return new WorkspaceMasterApi(transport, entryPoint);
+        return new WorkspaceMasterApi(transport, entryPoint, refreshToken);
     }
 
     private static createAxiosInstance(config: IRestAPIConfig): AxiosInstance {

--- a/src/json-rpc/workspace-master-api.ts
+++ b/src/json-rpc/workspace-master-api.ts
@@ -60,7 +60,7 @@ export interface IWorkspaceMasterApi {
  */
 export class WorkspaceMasterApi implements IWorkspaceMasterApi {
 
-    private refreshToken: RefreshToken;
+    private refreshToken?: RefreshToken;
     private jsonRpcApiClient: JsonRpcApiClient;
     private clientId: string;
     private wsMasterEventEmitter: EventEmitter;
@@ -76,7 +76,7 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
 
     constructor (client: ICommunicationClient,
                  entryPoint: string,
-                 refreshToken: RefreshToken) {
+                 refreshToken?: RefreshToken) {
         client.addListener('open', () => this.onConnectionOpen());
         client.addListener('close', () => this.onConnectionClose());
 
@@ -98,24 +98,27 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
      * @returns {Promise<any>}
      */
     connect(): Promise<any> {
-        return this.refreshToken().then((newToken) => {
-            const params: string[] = [`token=${newToken}`];
+        if (this.refreshToken) {
+            return this.refreshToken().then((newToken) => {
+                const params: string[] = [`token=${newToken}`];
 
-            if (this.clientId) {
-                params.push(`clientId=${this.clientId}`);
-            }
+                if (this.clientId) {
+                    params.push(`clientId=${this.clientId}`);
+                }
 
-            let entrypoint = this.entryPoint + this.websocketContext;
-            const queryStr = params.join('&');
-            if (/\?/.test(entrypoint) === false) {
-                entrypoint = entrypoint + '?' + queryStr;
-            } else {
-                entrypoint = entrypoint + '&' + queryStr;
-            }
-            return this.jsonRpcApiClient.connect(entrypoint).then(() => {
-                return this.fetchClientId();
+                let entrypoint = this.entryPoint + this.websocketContext;
+                const queryStr = params.join('&');
+                if (/\?/.test(entrypoint) === false) {
+                    entrypoint = entrypoint + '?' + queryStr;
+                } else {
+                    entrypoint = entrypoint + '&' + queryStr;
+                }
+                return this.jsonRpcApiClient.connect(entrypoint).then(() => {
+                    return this.fetchClientId();
+                });
             });
-        });
+        }
+        return Promise.resolve(undefined);
     }
 
     /**

--- a/src/json-rpc/workspace-master-api.ts
+++ b/src/json-rpc/workspace-master-api.ts
@@ -32,10 +32,11 @@ const SUBSCRIBE = 'subscribe';
 const UNSUBSCRIBE = 'unsubscribe';
 
 export type WebSocketsStatusChangeCallback = (failingWebSockets: string[]) => void;
+export type RefreshToken = () => Promise<string | Error>;
 
 export interface IWorkspaceMasterApi {
     onDidWebSocketStatusChange(callback: WebSocketsStatusChangeCallback): void;
-    connect(entryPoint: string): Promise<any>;
+    connect(): Promise<any>;
     subscribeEnvironmentOutput(workspaceId: string, callback: Function): void;
     unSubscribeEnvironmentOutput(workspaceId: string, callback: Function): void;
     subscribeEnvironmentStatus(workspaceId: string, callback: Function): void;
@@ -58,6 +59,8 @@ export interface IWorkspaceMasterApi {
  * @author Ann Shumilova
  */
 export class WorkspaceMasterApi implements IWorkspaceMasterApi {
+
+    private refreshToken: RefreshToken;
     private jsonRpcApiClient: JsonRpcApiClient;
     private clientId: string;
     private wsMasterEventEmitter: EventEmitter;
@@ -68,16 +71,21 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
     private reconnectionDelay = 30000;
     private reconnectionInitialDelay = 1000;
     private failingWebsockets: Set<string>;
+    private websocketContext = '/api/websocket';
+    private entryPoint: string;
 
     constructor (client: ICommunicationClient,
-                 entryPoint: string) {
-        client.addListener('open', () => this.onConnectionOpen(entryPoint));
-        client.addListener('close', () => this.onConnectionClose(entryPoint));
+                 entryPoint: string,
+                 refreshToken: RefreshToken) {
+        client.addListener('open', () => this.onConnectionOpen());
+        client.addListener('close', () => this.onConnectionClose());
 
         this.clientId = '';
         this.jsonRpcApiClient = new JsonRpcApiClient(client);
         this.wsMasterEventEmitter = new EventEmitter();
         this.failingWebsockets = new Set();
+        this.entryPoint = entryPoint;
+        this.refreshToken = refreshToken;
     }
 
     onDidWebSocketStatusChange(callback: WebSocketsStatusChangeCallback): void {
@@ -87,24 +95,26 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
     /**
      * Opens connection to pointed entryPoint.
      *
-     * @param entryPoint
      * @returns {Promise<any>}
      */
-    connect(entryPoint: string): Promise<any> {
-        if (this.clientId) {
-            let clientId = `clientId=${this.clientId}`;
-            // in case of reconnection
-            // we need to test entryPoint on existing query parameters
-            // to add already gotten clientId
-            if (/\?/.test(entryPoint) === false) {
-                clientId = '?' + clientId;
-            } else {
-                clientId = '&' + clientId;
+    connect(): Promise<any> {
+        return this.refreshToken().then((newToken) => {
+            const params: string[] = [`token=${newToken}`];
+
+            if (this.clientId) {
+                params.push(`clientId=${this.clientId}`);
             }
-            entryPoint += clientId;
-        }
-        return this.jsonRpcApiClient.connect(entryPoint).then(() => {
-            return this.fetchClientId();
+
+            let entrypoint = this.entryPoint + this.websocketContext;
+            const queryStr = params.join('&');
+            if (/\?/.test(entrypoint) === false) {
+                entrypoint = entrypoint + '?' + queryStr;
+            } else {
+                entrypoint = entrypoint + '&' + queryStr;
+            }
+            return this.jsonRpcApiClient.connect(entrypoint).then(() => {
+                return this.fetchClientId();
+            });
         });
     }
 
@@ -253,19 +263,19 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
         return this.clientId;
     }
 
-    private onConnectionOpen(entryPoint: string): void {
+    private onConnectionOpen(): void {
         if (this.reconnectionAttemptNumber !== 0) {
-            this.failingWebsockets.delete(entryPoint);
+            this.failingWebsockets.delete(this.entryPoint);
             this.wsMasterEventEmitter.emit(this.webSocketStatusChangeEventName, this.failingWebsockets);
             console.warn('WebSocket connection is opened.');
         }
         this.reconnectionAttemptNumber = 0;
     }
 
-    private onConnectionClose(entryPoint: string): void {
+    private onConnectionClose(): void {
         console.warn('WebSocket connection is closed.');
         if (this.reconnectionAttemptNumber === 5) {
-            this.failingWebsockets.add(entryPoint);
+            this.failingWebsockets.add(this.entryPoint);
             this.wsMasterEventEmitter.emit(this.webSocketStatusChangeEventName, this.failingWebsockets);
         } else if (this.reconnectionAttemptNumber === this.maxReconnectionAttempts) {
             console.warn('The maximum number of attempts to reconnect WebSocket has been reached.');
@@ -288,7 +298,7 @@ export class WorkspaceMasterApi implements IWorkspaceMasterApi {
         }
         setTimeout(() => {
             console.warn(`WebSocket is reconnecting, attempt #${this.reconnectionAttemptNumber} out of ${this.maxReconnectionAttempts}...`);
-            this.connect(entryPoint);
+            this.connect();
         }, delay);
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR in conjunction with https://github.com/eclipse/che-dashboard/pull/134 makes it so that you can refresh a token when a websocket is reconnecting. That way, the token used when establishing the websocket connection is always valid. It also removes websocket context.

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/18490#issuecomment-760079244

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>