### PR TITLE
Add getCurrentUserProfile api call

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -166,6 +166,7 @@ export interface IRemoteAPI {
      * Return the current authenticated user
      */
     getCurrentUser(): Promise<User>;
+    getCurrentUserProfile(): Promise<che.user.Profile>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
@@ -427,10 +428,22 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getCurrentUser(): Promise<User> {
+    public getCurrentUser(): Promise<User> {
         return new Promise((resolve, reject) => {
             this.remoteAPI.getCurrentUser()
                 .then((response: AxiosResponse<User>) => {
+                    resolve(response.data);
+                })
+                .catch((error: AxiosError) => {
+                    reject(new RequestError(error));
+                });
+        });
+    }
+
+    public getCurrentUserProfile(): Promise<che.user.Profile> {
+        return new Promise((resolve, reject) => {
+            this.remoteAPI.getCurrentUserProfile()
+                .then((response: AxiosResponse<che.user.Profile>) => {
                     resolve(response.data);
                 })
                 .catch((error: AxiosError) => {

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -71,6 +71,7 @@ export interface IResources {
     getOAuthProviders(): AxiosPromise<any[]>;
     deleteSshKey(service: string, name: string): AxiosPromise<void>;
     getCurrentUser(): AxiosPromise<User>;
+    getCurrentUserProfile(): AxiosPromise<che.user.Profile>;
     getUserPreferences(filter: string | undefined): AxiosPromise<Preferences>;
     updateUserPreferences(update: Preferences): AxiosPromise<Preferences>;
     replaceUserPreferences(preferences: Preferences): AxiosPromise<Preferences>;
@@ -233,6 +234,14 @@ export class Resources implements IResources {
             method: 'GET',
             baseURL: this.baseUrl,
             url: `/user`,
+        });
+    }
+
+    public getCurrentUserProfile(): AxiosPromise<che.user.Profile> {
+        return this.axios.request<User>({
+            method: 'GET',
+            baseURL: this.baseUrl,
+            url: `/profile`,
         });
     }
 

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -104,7 +104,7 @@ describe('RestAPI >', () => {
         expect(axios.request).toHaveBeenCalledWith({
             'baseURL': '/api',
             'method': 'GET',
-            'url': `/devfile`,
+            'url': '/devfile',
         });
         expect(schema).toBe(devfileSchema);
     });
@@ -174,6 +174,28 @@ describe('RestAPI >', () => {
         } as mockAxios.AxiosError;
         const requestError = new RequestError(axiosError);
         expect(requestError.message).toBe(`"${code}" returned by "${url}"."`);
+    });
+
+    it('should returns current user profile', async () => {
+        const userProfile = {
+            attributes: {
+                firstName: 'John',
+                lastName: 'Doe',
+                preferred_username: 'Johnny',
+            },
+            email: 'johndoe@test.com',
+            userId: 'john-doe-id',
+        };
+        axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: userProfile}));
+        const schema = await restApi.getCurrentUserProfile();
+
+        expect(axios.request).toHaveBeenCalledTimes(1);
+        expect(axios.request).toHaveBeenCalledWith({
+            'baseURL': '/api',
+            'method': 'GET',
+            'url': '/profile',
+        });
+        expect(schema).toBe(userProfile);
     });
 
 });


### PR DESCRIPTION
This PR makes it so that you can get the user profile information through the workspace client.

It is needed for  https://github.com/eclipse/che/issues/18685

Signed-off-by: Oleksii Orel <oorel@redhat.com>