### PR TITLE
Listen to runtime/log instead of deprecated machine/log

### DIFF
--- a/src/json-rpc/workspace-master-api.ts
+++ b/src/json-rpc/workspace-master-api.ts
@@ -14,7 +14,7 @@ import {JsonRpcApiClient} from './json-rpc-api-client';
 import {EventEmitter} from 'events';
 
 const enum MasterChannels {
-    ENVIRONMENT_OUTPUT = 'machine/log',
+    ENVIRONMENT_OUTPUT = 'runtime/log',
     ENVIRONMENT_STATUS = 'machine/statusChanged',
     WS_AGENT_OUTPUT = 'installer/log',
     WORKSPACE_STATUS = 'workspace/statusChanged',


### PR DESCRIPTION
Listen to runtime/log instead of deprecated machine/log https://github.com/eclipse/che/blob/b562d092c657918c2633ba00dfd2e9779fe3cd68/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java#L190

After it's merged I'll create PR against Dashboard to use newer workspace client

It's one of two steps to fix https://github.com/eclipse/che/issues/19028