### PR TITLE
Add in version parameter to getDevfileSchema

### DIFF
--- a/src/rest/remote-api.ts
+++ b/src/rest/remote-api.ts
@@ -196,7 +196,7 @@ export interface IRemoteAPI {
     /**
      * Returns a devfile schema object.
      */
-    getDevfileSchema<T = Object>(): Promise<T>;
+    getDevfileSchema<T = Object>(version?: string): Promise<T>;
     /**
      * Returns the che server api information
      */
@@ -536,9 +536,9 @@ export class RemoteAPI implements IRemoteAPI {
         });
     }
 
-    getDevfileSchema<T = Object>(): Promise<T> {
+    getDevfileSchema<T = Object>(version?: string): Promise<T> {
         return new Promise<T>((resolve, reject) => {
-            this.remoteAPI.getDevfileSchema<T>()
+            this.remoteAPI.getDevfileSchema<T>(version)
                 .then((response: AxiosResponse<T>) => {
                     resolve(response.data);
                 })

--- a/src/rest/resources.ts
+++ b/src/rest/resources.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
 import { che } from '@eclipse-che/api';
 import * as Qs from 'qs';
 
@@ -79,7 +79,7 @@ export interface IResources {
     getOAuthToken(oAuthProvider: string): AxiosPromise<{ token: string }>;
     updateActivity(workspaceId: string): AxiosPromise<void>;
     getKubernetesNamespace<T>(): AxiosPromise<T>;
-    getDevfileSchema<T>(): AxiosPromise<T>;
+    getDevfileSchema<T>(version?: string): AxiosPromise<T>;
     getApiInfo<T>(): AxiosPromise<T>;
 }
 
@@ -319,12 +319,18 @@ export class Resources implements IResources {
         });
     }
 
-    public getDevfileSchema<T>(): AxiosPromise<T> {
-        return this.axios.request<T>({
+    public getDevfileSchema<T>(version?: string): AxiosPromise<T> {
+        const requestOptions = {
             method: 'GET',
             baseURL: this.baseUrl,
-            url: this.devfileUrl,
-        });
+            url: this.devfileUrl
+        } as AxiosRequestConfig;
+        if (version) {
+            requestOptions.params = {
+                version
+            };
+        }
+        return this.axios.request<T>(requestOptions);
     }
 
     public getKubernetesNamespace<T>(): AxiosPromise<T> {


### PR DESCRIPTION
This PR makes it so that you can use a version parameter to specify the devfile schema version you want. Version must be either undefined (in which case 1.0.0 is returned), 1.0.0 or 2.0.0. See https://github.com/eclipse/che/pull/19043 for more info


Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>